### PR TITLE
Remove testapp from installed files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     license='BSD License',
     platforms=['OS Independent'],
     packages=find_packages(
-        exclude=['tests']
+        exclude=['tests', 'testapp']
     ),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
'tests' is left in-place for future usage or local (non-repository) test
cases. To be removed at maintainer discretion.