### PR TITLE
Extend item selector to work with stacked inlines post django 1.9

### DIFF
--- a/admin_ordering/static/admin_ordering/admin_ordering.js
+++ b/admin_ordering/static/admin_ordering/admin_ordering.js
@@ -24,7 +24,7 @@ django.jQuery(function($){
             });
         } else if (data.stacked) {
             $('#' + data.prefix + '-group').sortable({
-                items: '>.has_original',
+                items: '>.has_original,>>.has_original',
                 update: function(event, ui) {
                     updateOrdering($('.dynamic-' + data.prefix));
                 }


### PR DESCRIPTION
Beginning with Django 1.10 Stacked inlines are wrapped in an additional fieldset tag.