### PR TITLE
Fixed error on save when inlines have extra > 0

### DIFF
--- a/admin_ordering/static/admin_ordering/admin_ordering.js
+++ b/admin_ordering/static/admin_ordering/admin_ordering.js
@@ -76,7 +76,7 @@ django.jQuery(function($){
                     ui.item.css('height', ui.item.outerHeight());
                 },
                 update: function(event, ui) {
-                    updateOrdering($('.dynamic-' + data.prefix));
+                    updateOrdering($('.has_original.dynamic-' + data.prefix));
                 },
                 stop: function(event, ui){
                     autoHorizontalOverflow();
@@ -104,7 +104,7 @@ django.jQuery(function($){
                     updatePlaceholderHeight(ui);
                 },
                 update: function(event, ui) {
-                    updateOrdering($('.dynamic-' + data.prefix));
+                    updateOrdering($('.has_original.dynamic-' + data.prefix));
                 },
                 stop: function(event, ui){
                     autoHorizontalOverflow();


### PR DESCRIPTION
The current js updates the ordering field also for blank extra rows, this is causing error on save if the inlined model has required fields.
This patch just updates the ordering field for inlines that have .has_original class.